### PR TITLE
Use wait and run inside other scripts to get key.

### DIFF
--- a/scripts/wait_and_both.sh
+++ b/scripts/wait_and_both.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-./scripts/wait_for_it.sh $POLYSWARMD_HOST:$POLYSWARMD_PORT -t 0
-microengine --keyfile docker/keyfile --password password --backend multi
+./scripts/wait_and_run.sh --keyfile docker/keyfile --password password --backend multi

--- a/scripts/wait_and_clam.sh
+++ b/scripts/wait_and_clam.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-./scripts/wait_for_it.sh $POLYSWARMD_HOST:$POLYSWARMD_PORT -t 0
-microengine --keyfile docker/keyfile --password password --backend clamav
+./scripts/wait_and_run.sh --keyfile docker/keyfile --password password --backend clamav


### PR DESCRIPTION
The tutorials were failing because these scripts did not get the API key first. Routed them through wait_and_run. This is a temp fix, until I get dockerize in this project.